### PR TITLE
fixed: access recovery plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: 
   - swift
 
-osx_image: xcode10.1
+osx_image: xcode10.2
 
 branches:
   only:
@@ -10,7 +10,7 @@ branches:
 
 env:
   matrix:
-    - TEST_SDK=iphonesimulator12.1 OS=12.1 NAME='iPhone X'
+    - TEST_SDK=iphonesimulator12.2 OS=12.2 NAME='iPhone X'
 
 before_install:
   - gem install slather --no-ri --no-rdoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ env:
     - TEST_SDK=iphonesimulator12.2 OS=12.2 NAME='iPhone X'
 
 before_install:
-  - gem install slather --no-ri --no-rdoc
+  - gem install slather --no-document
   - gem uninstall cocoapods -a -x
-  - gem install cocoapods --no-ri --no-rdoc
+  - gem install cocoapods --no-document
   - pod install
 
 script:

--- a/Buya.podspec
+++ b/Buya.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |spec|
   spec.name               = 'Buya'
-  spec.version            = '1.0.1'
+  spec.version            = '1.0.2'
   spec.summary            = 'Network abstraction framework'
   spec.homepage           = 'https://github.com/Puasonych/Buya'
   spec.license            = { :type => 'MIT', :file => 'LICENSE' }
   spec.authors            = { 'Erik Basargin' => 'basargin.erik@gmail.com', 'Kirill Saltykov' => 'kirill.salti@gmail.com' }
   spec.social_media_url   = 'https://twitter.com/Puasonych'
   spec.source             = { :git => 'https://github.com/Puasonych/Buya.git', :tag => spec.version }
-  spec.swift_version      = '4.2'
+  spec.swift_version      = '5'
 
   spec.ios.deployment_target  = '8.0'
 
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'Core' do |subspec|
     subspec.source_files = 'Buya/**/*.swift'
     subspec.framework = 'Foundation'
-    subspec.dependency 'RxSwift', '~> 4.4'
-    subspec.dependency 'RxCocoa', '~> 4.4'
+    subspec.dependency 'RxSwift', '~> 4.5'
+    subspec.dependency 'RxCocoa', '~> 4.5'
   end
 end

--- a/Buya.xcodeproj/project.pbxproj
+++ b/Buya.xcodeproj/project.pbxproj
@@ -655,7 +655,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -681,7 +681,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.three-man-army.Buya";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -700,7 +700,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.three-man-army.BuyaTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -719,7 +719,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.three-man-army.BuyaTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Buya/Extensions/Single+Data.swift
+++ b/Buya/Extensions/Single+Data.swift
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 
 public extension Single where Element == Data {
-    public func map<T: Decodable>(_ type: T.Type, using decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
+    func map<T: Decodable>(_ type: T.Type, using decoder: JSONDecoder = JSONDecoder()) -> Single<T> {
         return self.asObservable().flatMap({ (data) -> Observable<T> in
             do {
                 return Observable.just(try decoder.decode(type, from: data))

--- a/Buya/Info.plist
+++ b/Buya/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Podfile
+++ b/Podfile
@@ -7,17 +7,17 @@ target 'Buya' do
 
   # Pods for Buya
   pod 'RxAtomic', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.4.2'
-  pod 'RxSwift', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.4.2'
-  pod 'RxCocoa', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.4.2'
+  pod 'RxSwift', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.5.0'
+  pod 'RxCocoa', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.5.0'
   
   target 'BuyaTests' do
     inherit! :search_paths
     # Pods for testing
     pod 'RxAtomic', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.4.2'
-    pod 'RxSwift', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.4.2'
-    pod 'RxCocoa', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.4.2'
-    pod 'RxBlocking', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.4.2'
-    pod 'RxTest', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.4.2'
+    pod 'RxSwift', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.5.0'
+    pod 'RxCocoa', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.5.0'
+    pod 'RxBlocking', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.5.0'
+    pod 'RxTest', :git => 'https://github.com/ReactiveX/RxSwift.git', :tag => '4.5.0'
   end
   
 end

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Network abstraction framework
 For Buya, use the following entry in your Podfile:
 
 ```rb
-pod 'RxSwift', '~> 4.0'
-pod 'RxCocoa', '~> 4.0'
+pod 'RxSwift', '~> 4.5'
+pod 'RxCocoa', '~> 4.5'
 pod 'Buya', '~> 1.0'
 ```
 


### PR DESCRIPTION
The RetryWhen was removed because it’s repeat full Observable sequence of request. This caused logic error with refreshing tokens.